### PR TITLE
[IMP] added minio image x86 emulation for arm based systems

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -63,6 +63,7 @@ services:
   minio:
     container_name: minio-container
     image: quay.io/minio/minio:RELEASE.2023-11-15T20-43-25Z.fips
+    platform: linux/x86_64
     command: server --console-address ":9001" /minio-data
     ports:
       - '9000:9000'


### PR DESCRIPTION
Minio x86 container emulation for ARM based systems (such as Apple-Silicon)

Docker Ref: https://www.docker.com/blog/multi-arch-images/